### PR TITLE
fix group button reset when state flipped

### DIFF
--- a/atoms/default/client/css/main.scss
+++ b/atoms/default/client/css/main.scss
@@ -707,6 +707,7 @@ body.ios {
 .finish-portrait-image {
     display: none;
     width: 300px;
+
 }
 
 #reset-button {
@@ -728,12 +729,14 @@ body.ios {
 
 .elex-map {
     width: 100%;
-    max-width: calc(100%);
+    height: 100%;
+    max-width: calc(60%);
+    max-height: calc(80%);
     margin: 10px;
-    flex-shrink: 0;
-
-    // float: left;
+    float: left;
     // overflow: visible !important;
+
+
 }
 
 
@@ -743,8 +746,6 @@ body.ios {
 }
 
 .finish-wrapper {
-    // display: flex;
-    display: flex;
-    align-items: flex-start;
+    overflow: hidden;
 
 }

--- a/atoms/default/client/js/app.js
+++ b/atoms/default/client/js/app.js
@@ -202,15 +202,6 @@ function createCards(data) {
             .style("display", votesBiden > votesTrump ? 'block' : 'none')
         d3.select('.trump-win-portrait')
             .style("display", votesTrump > votesBiden ? 'block' : 'none')
-        // const finishPortraits = document.querySelectorAll(".finish-portrait-image");
-
-        // finishPortraits.forEach(function (portrait) {
-        //     portrait.classList.remove("show-portrait");
-        // });
-
-        // const winner = votesBiden > votesTrump ? "biden" : (votesTrump > votesBiden ? "trump" : '')
-        // const portraitEl = document.querySelector("." + candidate + "-portrait-" + mood);
-        // portraitEl.classList.add("show-portrait");
 
         // Reset button
         const resetButton = d3.select('.reset-button-div')
@@ -406,7 +397,7 @@ function createCards(data) {
                 .enter()
                 .append('button')
                 .text(name => "All to " + name)
-                .attr('class', d => 'group-candidate-button group-candidate-button--' + d.toLowerCase())
+                .attr('class', d => `group-candidate-button group-button--${groupName} group-candidate-button--` + d.toLowerCase())
 
             groupButtons
                 .on('click', canName => {
@@ -574,6 +565,12 @@ function createCards(data) {
                     updateTotals(prevTotals)
                     buttons
                         .classed('candidate-button--selected', n => n === canName)
+
+                    const selectedGroupButton = $(`.group-candidate-button--selected.group-button--${d.groups_in_use}`)
+
+                    if (selectedGroupButton != null && selectedGroupButton.innerHTML != "All to " + canName) {
+                        selectedGroupButton.classList.remove("group-candidate-button--selected")
+                    }
 
                     var trackingobject = {
                         component: "elex-preview-08-2020",


### PR DESCRIPTION
If group button is selected, when individual state card is flipped, group button now resets